### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementations of several algorithms for the traveling salesman problem in Juli
 From the Julia REPL execute
 ```julia
 julia> using Pkg
-julia> Pkg.add("https://github.com/claud10cv/TravelingSalesman.jl.git")
+julia> Pkg.add(url="https://github.com/claud10cv/TravelingSalesman.jl.git")
 ```
 
 ## Basic usage


### PR DESCRIPTION
Apparently in the latest version Pkg.add doesn't work if the argument name "url" is not specified since it handles it as a local path.